### PR TITLE
fix(sagas): update action type

### DIFF
--- a/src/sagas/counter.ts
+++ b/src/sagas/counter.ts
@@ -9,7 +9,7 @@ import {
 
 //AnyAction means the action can only be of one of the types of actions already made. Not very usefull
 
-export function* editCounter(action : AnyAction) {
+export function* editCounter(action : ReturnType<typeof addOne>) {
     console.log('action', action);
     try {
         yield put(addOne(action.payload));


### PR DESCRIPTION
Hey Tomas,
in this case `addOne` is a function, which expects a number input and returns the action object.
To get the type of this action, we can use builtin ts helper `ReturnType`, which takes a type of a function as generic argument and returns the type, that this function returns.

There are also helper functions in `typesafe-actions`, which allow you to create complex actions for async requests, like `request`/`success`/`error`. You can read more about them [here](https://github.com/piotrwitek/typesafe-actions#with-redux-saga-sagas).